### PR TITLE
handle creation of EFunction in tink.macro.Functions.asExpr

### DIFF
--- a/src/tink/template/Generator.hx
+++ b/src/tink/template/Generator.hx
@@ -101,11 +101,7 @@ class Generator {
             }
               
         case Function(name, args, body):            
-#if (haxe_ver >= 4)
-          functionBody(body, true).func(args, false).asExpr(FNamed(name, false));
-#else
           functionBody(body, true).func(args, false).asExpr(name);
-#end
         case Block(exprs):
           exprs.map(generateExpr).toBlock(pos);
       }

--- a/src/tink/template/Parser.hx
+++ b/src/tink/template/Parser.hx
@@ -576,11 +576,7 @@ class Parser {
         case Success('function'):
           var f = parseFunction();
           if (f.tpl == null)
-#if (haxe_ver >= 4)
-            Do(EFunction(FNamed(f.name, false), f.func).at(f.pos));
-#else
-            Do(EFunction(f.name, f.func).at(f.pos));
-#end
+            Do(f.func.asExpr(f.name, f.pos)); 
           else
             Function(f.name, f.func.args, f.tpl);          
         case Success('var'):


### PR DESCRIPTION
the FunctionKind enum in Haxe 4 AST has changed. I made a pull request for this in tink.macro.Functions. The changes here require this pull request